### PR TITLE
feat: change the l1 receiver datatype from "address" to "bytes"

### DIFF
--- a/system-contracts/SystemContractsHashes.json
+++ b/system-contracts/SystemContractsHashes.json
@@ -3,49 +3,49 @@
     "contractName": "AccountCodeStorage",
     "bytecodePath": "artifacts-zk/contracts-preprocessed/AccountCodeStorage.sol/AccountCodeStorage.json",
     "sourceCodePath": "contracts-preprocessed/AccountCodeStorage.sol",
-    "bytecodeHash": "0x0100007549287362e4263ea5b204f01fc3c7f2ac09d71e6eb21029698220f01a",
+    "bytecodeHash": "0x0100007596d8c236a02891ce6e5cae2ee8c175df680186676a1f7012daa022ec",
     "sourceCodeHash": "0xfbf66e830201c4b7fda14f0ddf28a53beb7fbb48a8406392bcfd0ef7ea9265c8"
   },
   {
     "contractName": "BootloaderUtilities",
     "bytecodePath": "artifacts-zk/contracts-preprocessed/BootloaderUtilities.sol/BootloaderUtilities.json",
     "sourceCodePath": "contracts-preprocessed/BootloaderUtilities.sol",
-    "bytecodeHash": "0x010007d1e53f2dca05f7e27ae5b7062291ed3a1470ca511140b8e786aae7eb77",
+    "bytecodeHash": "0x010007d184170033b5b0846d7ec097aee593daeee82d58ede2f555aa48edb358",
     "sourceCodeHash": "0x9ff5a2da00acfa145ee4575381ad386587d96b6a0309d05015974f4726881132"
   },
   {
     "contractName": "ComplexUpgrader",
     "bytecodePath": "artifacts-zk/contracts-preprocessed/ComplexUpgrader.sol/ComplexUpgrader.json",
     "sourceCodePath": "contracts-preprocessed/ComplexUpgrader.sol",
-    "bytecodeHash": "0x01000055c1f27b8316ba61bf07959b11cf3b2a418aa357ccc5531c0914a2da27",
+    "bytecodeHash": "0x01000055262e75ac0e0ccb7247051a603e151dcd34238f88ff38f1b6db323135",
     "sourceCodeHash": "0x0aa5d7ed159e783acde47856b13801b7f2268ba39b2fa50807fe3d705c506e96"
   },
   {
     "contractName": "Compressor",
     "bytecodePath": "artifacts-zk/contracts-preprocessed/Compressor.sol/Compressor.json",
     "sourceCodePath": "contracts-preprocessed/Compressor.sol",
-    "bytecodeHash": "0x01000179842b5aa1c76036f5b90652fe614dacb28438a89649d6ca48131bd402",
+    "bytecodeHash": "0x01000179ebd431fb660c40c839885c734bc29d56d9f54317668f502af3b3775d",
     "sourceCodeHash": "0xd43ac120a50398e0d6bdcfcf807154bfeece0c231509a0eb2e00bcad744e60cd"
   },
   {
     "contractName": "ContractDeployer",
     "bytecodePath": "artifacts-zk/contracts-preprocessed/ContractDeployer.sol/ContractDeployer.json",
     "sourceCodePath": "contracts-preprocessed/ContractDeployer.sol",
-    "bytecodeHash": "0x010005215fda00bfbf95847a13078bd16cdcb1b875534261c1dda9940c7754fe",
+    "bytecodeHash": "0x01000523ff49c364eb57688e95179b565ff6cdd9805da091bddceddeda53206a",
     "sourceCodeHash": "0x635301b824f927b4d17b3d9974cf6abbf979dda49e610805637db7c677d5f522"
   },
   {
     "contractName": "Create2Factory",
     "bytecodePath": "artifacts-zk/contracts-preprocessed/Create2Factory.sol/Create2Factory.json",
     "sourceCodePath": "contracts-preprocessed/Create2Factory.sol",
-    "bytecodeHash": "0x0100004bc85f45ebf0f0bf004752bcbff1bb99792d6cc6494227970ec77fe53b",
+    "bytecodeHash": "0x0100004b37aaf9974ab8861e2ac5228775881369d0f3494d04d82979ed0a1265",
     "sourceCodeHash": "0x217e65f55c8add77982171da65e0db8cc10141ba75159af582973b332a4e098a"
   },
   {
     "contractName": "DefaultAccount",
     "bytecodePath": "artifacts-zk/contracts-preprocessed/DefaultAccount.sol/DefaultAccount.json",
     "sourceCodePath": "contracts-preprocessed/DefaultAccount.sol",
-    "bytecodeHash": "0x01000563374c277a2c1e34659a2a1e87371bb6d852ce142022d497bfb50b9e32",
+    "bytecodeHash": "0x010005634452e3015fafe22ff894481957c3ed5597564acb01196ee4bcdec8f9",
     "sourceCodeHash": "0xa42423712ddaa8f357d26e46825fda80a9a870d0ac7ff52c98884355f1173ec7"
   },
   {
@@ -59,56 +59,56 @@
     "contractName": "ImmutableSimulator",
     "bytecodePath": "artifacts-zk/contracts-preprocessed/ImmutableSimulator.sol/ImmutableSimulator.json",
     "sourceCodePath": "contracts-preprocessed/ImmutableSimulator.sol",
-    "bytecodeHash": "0x0100003de00c5ceaa3fdf4566a9822ce94abe676f68b17a6ae11c453e14455fd",
+    "bytecodeHash": "0x0100003d08e40e238ef3ab203020ecd0bb3a7dff342db84a50e8268756f7c0fe",
     "sourceCodeHash": "0x30df621c72cb35b8820b902b91057f72d0214a0e4a6b7ad4c0847e674e8b9df8"
   },
   {
     "contractName": "KnownCodesStorage",
     "bytecodePath": "artifacts-zk/contracts-preprocessed/KnownCodesStorage.sol/KnownCodesStorage.json",
     "sourceCodePath": "contracts-preprocessed/KnownCodesStorage.sol",
-    "bytecodeHash": "0x0100007d82d4a2eb62e539e3c89cc641f507132b247022ba05ef1ddfed2b0073",
+    "bytecodeHash": "0x0100007d37452cb8c3f69ed85ae87ebaac4e3660a8f3cdf3f7155f0a68f2472b",
     "sourceCodeHash": "0x51d388adc58f67ef975a94a7978caa60ed8a0df9d3bd9ac723dfcfc540286c70"
   },
   {
     "contractName": "L1Messenger",
     "bytecodePath": "artifacts-zk/contracts-preprocessed/L1Messenger.sol/L1Messenger.json",
     "sourceCodePath": "contracts-preprocessed/L1Messenger.sol",
-    "bytecodeHash": "0x010002b97ebf3c481ead775617590ffca139bee428e443aa49eb38b6a5b83657",
+    "bytecodeHash": "0x010002b924ad42aa09b1d58c2506536668ba1d36ab25d077ddbffe56b00f7659",
     "sourceCodeHash": "0x35c189f3babf5c7a9ce2590bed9eb62b59766e358b7733fdb1bc33f4c232f765"
   },
   {
     "contractName": "L2BaseToken",
     "bytecodePath": "artifacts-zk/contracts-preprocessed/L2BaseToken.sol/L2BaseToken.json",
     "sourceCodePath": "contracts-preprocessed/L2BaseToken.sol",
-    "bytecodeHash": "0x010001039329e4bb55b24531c7e7d27ed40d2c82ad145033fdd5ed5b8ea86cf3",
-    "sourceCodeHash": "0x76ac95c12820d9a02cd1f177eab59092d99463816f2616e1e0f44637bf791a43"
+    "bytecodeHash": "0x0100011ff20431c12a48e6c7d6b232199055ba67339a8f334f6f37a32a7727a9",
+    "sourceCodeHash": "0x279f06761bb0704afee32747ecf22496588cc6dc6dddd4c9e928a2b7716ee930"
   },
   {
     "contractName": "MsgValueSimulator",
     "bytecodePath": "artifacts-zk/contracts-preprocessed/MsgValueSimulator.sol/MsgValueSimulator.json",
     "sourceCodePath": "contracts-preprocessed/MsgValueSimulator.sol",
-    "bytecodeHash": "0x010000695a1e821b6d5fcb25e25793b81de0bdca3ff8277e3ac93a38e729e0a1",
+    "bytecodeHash": "0x01000069e1260706acb07afafa06b02c38de10c16108fc8d8f4aea56d5e6ae5f",
     "sourceCodeHash": "0x3f9e0af527875bebcdc20ca4ecb6822305877fd6038e4c4c58854d000b9ac115"
   },
   {
     "contractName": "NonceHolder",
     "bytecodePath": "artifacts-zk/contracts-preprocessed/NonceHolder.sol/NonceHolder.json",
     "sourceCodePath": "contracts-preprocessed/NonceHolder.sol",
-    "bytecodeHash": "0x010000e563d4ad7b4822cc19d8f74f2c41ee3d3153379be4b02b27d4498d52b6",
+    "bytecodeHash": "0x010000e5f5c98989f0732a57d2364c2d42aba84dec8e7165c33a98913f938fef",
     "sourceCodeHash": "0x91847512344ac5026e9fd396189c23ad9e253f22cb6e2fe65805c20c915797d4"
   },
   {
     "contractName": "PubdataChunkPublisher",
     "bytecodePath": "artifacts-zk/contracts-preprocessed/PubdataChunkPublisher.sol/PubdataChunkPublisher.json",
     "sourceCodePath": "contracts-preprocessed/PubdataChunkPublisher.sol",
-    "bytecodeHash": "0x01000049eb6d79244e74e5286ed4d3f6eef2b5eb746b67d98691dbc28fa16984",
+    "bytecodeHash": "0x01000049af77511237e8570164c843cd3eba91a648f7325013a584781769d4d3",
     "sourceCodeHash": "0xbc62d673c2cf9ba2d2148e5e2f99ea577cd357c6fd3ad7d248f670c750050faa"
   },
   {
     "contractName": "SystemContext",
     "bytecodePath": "artifacts-zk/contracts-preprocessed/SystemContext.sol/SystemContext.json",
     "sourceCodePath": "contracts-preprocessed/SystemContext.sol",
-    "bytecodeHash": "0x010001b3f2c3a6bdd5ad00ae29a7cbbb32dca3c31fb608b5cd52f8f3056a3847",
+    "bytecodeHash": "0x010001b38ec300790c0587f5c79a3f57d833e0a48cf5fe5663bb5345269b6bf0",
     "sourceCodeHash": "0xb90284d78f48a958d082c4c877fc91ec292d05f0e388c6c78e6cce6d3b069a63"
   },
   {
@@ -178,35 +178,35 @@
     "contractName": "bootloader_test",
     "bytecodePath": "bootloader/build/artifacts/bootloader_test.yul.zbin",
     "sourceCodePath": "bootloader/build/bootloader_test.yul",
-    "bytecodeHash": "0x010003cbf67ee7370dd2e77fb9ad39f718ded9354be174ea3009c6cb4fb8c06d",
-    "sourceCodeHash": "0x232e09be0ce4a92a3b77558e5724ab67e9deaf68e12e8be682a999655203b066"
+    "bytecodeHash": "0x010003cbee0cc4cd4d43faa6a6e8cd1750595aba444b37498bc61f9fe2cc3242",
+    "sourceCodeHash": "0xc9587a45167aafbfcec7fdafb3f6409f7341411eb9eba2231abdfa7de1f3d925"
   },
   {
     "contractName": "fee_estimate",
     "bytecodePath": "bootloader/build/artifacts/fee_estimate.yul.zbin",
     "sourceCodePath": "bootloader/build/fee_estimate.yul",
-    "bytecodeHash": "0x01000951968c701c02714779299712d9da6e400e56c78d0d07acd984bfe7242a",
-    "sourceCodeHash": "0x9b2d51a24186af7ef58f7c8f53d77f6732f3a8d2dbde556fc8c1152957855fa5"
+    "bytecodeHash": "0x01000951296b20cb40d1473096cea5e1f07fbed1f5cce910ba8c98ee1eea6f47",
+    "sourceCodeHash": "0x232da808db40f37a78fe83b8faa73d4287da3a61a741e35259b9d3948991cfd7"
   },
   {
     "contractName": "gas_test",
     "bytecodePath": "bootloader/build/artifacts/gas_test.yul.zbin",
     "sourceCodePath": "bootloader/build/gas_test.yul",
-    "bytecodeHash": "0x010008d7dffe019f801bf2ee23b93f83afd80ea6d20c8efe82da71fd57cbcb5c",
-    "sourceCodeHash": "0xf6624fe716eec6bcd5d513f069f33d758271b304009d2bdf5c5b7d0573868a1c"
+    "bytecodeHash": "0x010008d71c14ef8264082251a434eaf7279aaec3c3d2b3132ebe4723b9d2ddbb",
+    "sourceCodeHash": "0x271c4762bd0ff170f127e45d4a526afc730d1820a59824dcce26b15d9e293c22"
   },
   {
     "contractName": "playground_batch",
     "bytecodePath": "bootloader/build/artifacts/playground_batch.yul.zbin",
     "sourceCodePath": "bootloader/build/playground_batch.yul",
-    "bytecodeHash": "0x01000957420977a293aab097a368f36b123247d87d4695a6cd27ac62598ab171",
-    "sourceCodeHash": "0x23293faa6627f60f8b4d61657c615cb2327162dd1e33c0968e9ab4d5dd605a20"
+    "bytecodeHash": "0x010009575d12cd2d588b852c43762aef66723ab2f2dddf9f526d7d90968e6654",
+    "sourceCodeHash": "0xe2597a2df37b33c2c0fe3d747327e2b60d3c5d2513aeddae65682fb3c6c33c9c"
   },
   {
     "contractName": "proved_batch",
     "bytecodePath": "bootloader/build/artifacts/proved_batch.yul.zbin",
     "sourceCodePath": "bootloader/build/proved_batch.yul",
-    "bytecodeHash": "0x010008e742608b21bf7eb23c1a9d0602047e3618b464c9b59c0fba3b3d7ab66e",
-    "sourceCodeHash": "0x8ac4971296d0546fc6366caa4089489177656cbc33cc21247947d98c28c6dee4"
+    "bytecodeHash": "0x010008e74e40a94b1c6e6eb5a1dfbbdbd9eb9e0ec90fd358d29e8c07c30d8491",
+    "sourceCodeHash": "0xc6d5f3e95ac13ca3f6ddee215f2a868ac4e2cf2ecdbf89d65a2ccda86202814d"
   }
 ]

--- a/system-contracts/SystemContractsHashes.json
+++ b/system-contracts/SystemContractsHashes.json
@@ -3,49 +3,49 @@
     "contractName": "AccountCodeStorage",
     "bytecodePath": "artifacts-zk/contracts-preprocessed/AccountCodeStorage.sol/AccountCodeStorage.json",
     "sourceCodePath": "contracts-preprocessed/AccountCodeStorage.sol",
-    "bytecodeHash": "0x0100007596d8c236a02891ce6e5cae2ee8c175df680186676a1f7012daa022ec",
+    "bytecodeHash": "0x01000075d58c2cea1d80b434fb70e256b90ba0fbe7b0bd1f5dc70350f7bdfd34",
     "sourceCodeHash": "0xfbf66e830201c4b7fda14f0ddf28a53beb7fbb48a8406392bcfd0ef7ea9265c8"
   },
   {
     "contractName": "BootloaderUtilities",
     "bytecodePath": "artifacts-zk/contracts-preprocessed/BootloaderUtilities.sol/BootloaderUtilities.json",
     "sourceCodePath": "contracts-preprocessed/BootloaderUtilities.sol",
-    "bytecodeHash": "0x010007d184170033b5b0846d7ec097aee593daeee82d58ede2f555aa48edb358",
+    "bytecodeHash": "0x010007d132c68997edf892423ae89079a3118e3506a6dad628b20a826c9ad0b7",
     "sourceCodeHash": "0x9ff5a2da00acfa145ee4575381ad386587d96b6a0309d05015974f4726881132"
   },
   {
     "contractName": "ComplexUpgrader",
     "bytecodePath": "artifacts-zk/contracts-preprocessed/ComplexUpgrader.sol/ComplexUpgrader.json",
     "sourceCodePath": "contracts-preprocessed/ComplexUpgrader.sol",
-    "bytecodeHash": "0x01000055262e75ac0e0ccb7247051a603e151dcd34238f88ff38f1b6db323135",
+    "bytecodeHash": "0x010000556b7218497abf194231c563756850bcc745bb781069a5f06c07e55f34",
     "sourceCodeHash": "0x0aa5d7ed159e783acde47856b13801b7f2268ba39b2fa50807fe3d705c506e96"
   },
   {
     "contractName": "Compressor",
     "bytecodePath": "artifacts-zk/contracts-preprocessed/Compressor.sol/Compressor.json",
     "sourceCodePath": "contracts-preprocessed/Compressor.sol",
-    "bytecodeHash": "0x01000179ebd431fb660c40c839885c734bc29d56d9f54317668f502af3b3775d",
+    "bytecodeHash": "0x0100017918dd335119ac124f424fb25787682ece5c072cfbad6026e73fe3911f",
     "sourceCodeHash": "0xd43ac120a50398e0d6bdcfcf807154bfeece0c231509a0eb2e00bcad744e60cd"
   },
   {
     "contractName": "ContractDeployer",
     "bytecodePath": "artifacts-zk/contracts-preprocessed/ContractDeployer.sol/ContractDeployer.json",
     "sourceCodePath": "contracts-preprocessed/ContractDeployer.sol",
-    "bytecodeHash": "0x01000523ff49c364eb57688e95179b565ff6cdd9805da091bddceddeda53206a",
+    "bytecodeHash": "0x010005210857411f7bd7433712d73ba533cb37ea58590f7479280ad2a02e3fd5",
     "sourceCodeHash": "0x635301b824f927b4d17b3d9974cf6abbf979dda49e610805637db7c677d5f522"
   },
   {
     "contractName": "Create2Factory",
     "bytecodePath": "artifacts-zk/contracts-preprocessed/Create2Factory.sol/Create2Factory.json",
     "sourceCodePath": "contracts-preprocessed/Create2Factory.sol",
-    "bytecodeHash": "0x0100004b37aaf9974ab8861e2ac5228775881369d0f3494d04d82979ed0a1265",
+    "bytecodeHash": "0x0100004b3423a2e2e5f444f29e44f904c7bf1cda21437d395fae1ce3dfb2cd81",
     "sourceCodeHash": "0x217e65f55c8add77982171da65e0db8cc10141ba75159af582973b332a4e098a"
   },
   {
     "contractName": "DefaultAccount",
     "bytecodePath": "artifacts-zk/contracts-preprocessed/DefaultAccount.sol/DefaultAccount.json",
     "sourceCodePath": "contracts-preprocessed/DefaultAccount.sol",
-    "bytecodeHash": "0x010005634452e3015fafe22ff894481957c3ed5597564acb01196ee4bcdec8f9",
+    "bytecodeHash": "0x01000563426437b886b132bf5bcf9b0d98c3648f02a6e362893db4345078d09f",
     "sourceCodeHash": "0xa42423712ddaa8f357d26e46825fda80a9a870d0ac7ff52c98884355f1173ec7"
   },
   {
@@ -59,56 +59,56 @@
     "contractName": "ImmutableSimulator",
     "bytecodePath": "artifacts-zk/contracts-preprocessed/ImmutableSimulator.sol/ImmutableSimulator.json",
     "sourceCodePath": "contracts-preprocessed/ImmutableSimulator.sol",
-    "bytecodeHash": "0x0100003d08e40e238ef3ab203020ecd0bb3a7dff342db84a50e8268756f7c0fe",
+    "bytecodeHash": "0x0100003d4dd9f3871a68dc910240f389487d6e8d2d8b4ddc5e5aa8ed47cadd9f",
     "sourceCodeHash": "0x30df621c72cb35b8820b902b91057f72d0214a0e4a6b7ad4c0847e674e8b9df8"
   },
   {
     "contractName": "KnownCodesStorage",
     "bytecodePath": "artifacts-zk/contracts-preprocessed/KnownCodesStorage.sol/KnownCodesStorage.json",
     "sourceCodePath": "contracts-preprocessed/KnownCodesStorage.sol",
-    "bytecodeHash": "0x0100007d37452cb8c3f69ed85ae87ebaac4e3660a8f3cdf3f7155f0a68f2472b",
+    "bytecodeHash": "0x0100007d8ff9ee312f91dc4c507e3aaeb0a876d9a1937384645f2be8c3db21de",
     "sourceCodeHash": "0x51d388adc58f67ef975a94a7978caa60ed8a0df9d3bd9ac723dfcfc540286c70"
   },
   {
     "contractName": "L1Messenger",
     "bytecodePath": "artifacts-zk/contracts-preprocessed/L1Messenger.sol/L1Messenger.json",
     "sourceCodePath": "contracts-preprocessed/L1Messenger.sol",
-    "bytecodeHash": "0x010002b924ad42aa09b1d58c2506536668ba1d36ab25d077ddbffe56b00f7659",
+    "bytecodeHash": "0x010002b92f1a7be267f5e192bd5fd24155250a47b8cf2f1300de89f691b60787",
     "sourceCodeHash": "0x35c189f3babf5c7a9ce2590bed9eb62b59766e358b7733fdb1bc33f4c232f765"
   },
   {
     "contractName": "L2BaseToken",
     "bytecodePath": "artifacts-zk/contracts-preprocessed/L2BaseToken.sol/L2BaseToken.json",
     "sourceCodePath": "contracts-preprocessed/L2BaseToken.sol",
-    "bytecodeHash": "0x0100011ff20431c12a48e6c7d6b232199055ba67339a8f334f6f37a32a7727a9",
+    "bytecodeHash": "0x0100011f147165d93b8ab21c15d6e123715da8ad8b8776c2da49bc890ffbe6e7",
     "sourceCodeHash": "0x279f06761bb0704afee32747ecf22496588cc6dc6dddd4c9e928a2b7716ee930"
   },
   {
     "contractName": "MsgValueSimulator",
     "bytecodePath": "artifacts-zk/contracts-preprocessed/MsgValueSimulator.sol/MsgValueSimulator.json",
     "sourceCodePath": "contracts-preprocessed/MsgValueSimulator.sol",
-    "bytecodeHash": "0x01000069e1260706acb07afafa06b02c38de10c16108fc8d8f4aea56d5e6ae5f",
+    "bytecodeHash": "0x010000699913d2a25f0382355554ed72c258e58d90950ba2e3a83ab439318f73",
     "sourceCodeHash": "0x3f9e0af527875bebcdc20ca4ecb6822305877fd6038e4c4c58854d000b9ac115"
   },
   {
     "contractName": "NonceHolder",
     "bytecodePath": "artifacts-zk/contracts-preprocessed/NonceHolder.sol/NonceHolder.json",
     "sourceCodePath": "contracts-preprocessed/NonceHolder.sol",
-    "bytecodeHash": "0x010000e5f5c98989f0732a57d2364c2d42aba84dec8e7165c33a98913f938fef",
+    "bytecodeHash": "0x010000e59b50f1c956a7427dfb7c1b33bcf9048ceeb4116eb26a6c5deef6184a",
     "sourceCodeHash": "0x91847512344ac5026e9fd396189c23ad9e253f22cb6e2fe65805c20c915797d4"
   },
   {
     "contractName": "PubdataChunkPublisher",
     "bytecodePath": "artifacts-zk/contracts-preprocessed/PubdataChunkPublisher.sol/PubdataChunkPublisher.json",
     "sourceCodePath": "contracts-preprocessed/PubdataChunkPublisher.sol",
-    "bytecodeHash": "0x01000049af77511237e8570164c843cd3eba91a648f7325013a584781769d4d3",
+    "bytecodeHash": "0x0100004964f77bae7187bc6a9b0da9e9b22cbb34649f15fced75cbfebd812c63",
     "sourceCodeHash": "0xbc62d673c2cf9ba2d2148e5e2f99ea577cd357c6fd3ad7d248f670c750050faa"
   },
   {
     "contractName": "SystemContext",
     "bytecodePath": "artifacts-zk/contracts-preprocessed/SystemContext.sol/SystemContext.json",
     "sourceCodePath": "contracts-preprocessed/SystemContext.sol",
-    "bytecodeHash": "0x010001b38ec300790c0587f5c79a3f57d833e0a48cf5fe5663bb5345269b6bf0",
+    "bytecodeHash": "0x010001b3a795b0c8d25bcf0067b1537049c477b9bc578be425507d0194756e25",
     "sourceCodeHash": "0xb90284d78f48a958d082c4c877fc91ec292d05f0e388c6c78e6cce6d3b069a63"
   },
   {

--- a/system-contracts/contracts/L2BaseToken.sol
+++ b/system-contracts/contracts/L2BaseToken.sol
@@ -69,7 +69,7 @@ contract L2BaseToken is IBaseToken, ISystemContract {
 
     /// @notice Initiate the withdrawal of the base token, funds will be available to claim on L1 `finalizeEthWithdrawal` method.
     /// @param _l1Receiver The address on L1 to receive the funds.
-    function withdraw(address _l1Receiver) external payable override {
+    function withdraw(bytes calldata _l1Receiver) external payable override {
         uint256 amount = _burnMsgValue();
 
         // Send the L2 log, a user could use it as proof of the withdrawal
@@ -109,7 +109,7 @@ contract L2BaseToken is IBaseToken, ISystemContract {
     }
 
     /// @dev Get the message to be sent to L1 to initiate a withdrawal.
-    function _getL1WithdrawMessage(address _to, uint256 _amount) internal pure returns (bytes memory) {
+    function _getL1WithdrawMessage(bytes calldata _to, uint256 _amount) internal pure returns (bytes memory) {
         return abi.encodePacked(IMailbox.finalizeEthWithdrawal.selector, _to, _amount);
     }
 

--- a/system-contracts/contracts/interfaces/IBaseToken.sol
+++ b/system-contracts/contracts/interfaces/IBaseToken.sol
@@ -17,7 +17,7 @@ interface IBaseToken {
 
     function mint(address _account, uint256 _amount) external;
 
-    function withdraw(address _l1Receiver) external payable;
+    function withdraw(bytes calldata _l1Receiver) external payable;
 
     function withdrawWithMessage(address _l1Receiver, bytes calldata _additionalData) external payable;
 
@@ -25,7 +25,7 @@ interface IBaseToken {
 
     event Transfer(address indexed from, address indexed to, uint256 value);
 
-    event Withdrawal(address indexed _l2Sender, address indexed _l1Receiver, uint256 _amount);
+    event Withdrawal(address indexed _l2Sender, bytes indexed _l1Receiver, uint256 _amount);
 
     event WithdrawalWithMessage(
         address indexed _l2Sender,

--- a/system-contracts/test/L2BaseToken.spec.ts
+++ b/system-contracts/test/L2BaseToken.spec.ts
@@ -170,9 +170,12 @@ describe("L2BaseToken tests", () => {
   describe("withdraw", () => {
     it("event, balance, totalsupply", async () => {
       const amountToWithdraw: BigNumber = ethers.utils.parseEther("1.0");
+      const btcAddress = ethers.utils.hexlify(
+        ethers.utils.toUtf8Bytes("bc1qy82gaw2htfd5sslplpgmz4ktf9y3k7pac2226k0wljlmw3atfw5qwm4av4")
+      );
       const message: string = ethers.utils.solidityPack(
-        ["bytes4", "address", "uint256"],
-        [mailboxIface.getSighash("finalizeEthWithdrawal"), wallets[1].address, amountToWithdraw]
+        ["bytes4", "bytes", "uint256"],
+        [mailboxIface.getSighash("finalizeEthWithdrawal"), btcAddress, amountToWithdraw]
       );
 
       await setResult("L1Messenger", "sendToL1", [message], {
@@ -187,9 +190,9 @@ describe("L2BaseToken tests", () => {
       const balanceBeforeWithdrawal: BigNumber = await L2BaseToken.balanceOf(L2BaseToken.address);
       const totalSupplyBefore = await L2BaseToken.totalSupply();
 
-      await expect(L2BaseToken.connect(richWallet).withdraw(wallets[1].address, { value: amountToWithdraw }))
+      await expect(L2BaseToken.connect(richWallet).withdraw(btcAddress, { value: amountToWithdraw }))
         .to.emit(L2BaseToken, "Withdrawal")
-        .withArgs(richWallet.address, wallets[1].address, amountToWithdraw);
+        .withArgs(richWallet.address, btcAddress, amountToWithdraw);
 
       const balanceAfterWithdrawal: BigNumber = await L2BaseToken.balanceOf(L2BaseToken.address);
       const totalSupplyAfter = await L2BaseToken.totalSupply();


### PR DESCRIPTION
# What ❔

- Change the l1_receiver data type from address to bytes type.
- Update the system contracts hashes using `yarn sc calculate-hashes:fix`

## Why ❔

The bitcoin address is different from the Ethereum address, for that we needed to modify the data type so the user can set his Bitcoin address when exit.

## Checklist

![test](https://github.com/user-attachments/assets/0610fa75-611c-4aae-8343-331da22a10ec)

- [X] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [X] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
