### PR TITLE
fix: change the receiver l1 datatype to bytes32

### DIFF
--- a/system-contracts/SystemContractsHashes.json
+++ b/system-contracts/SystemContractsHashes.json
@@ -3,49 +3,49 @@
     "contractName": "AccountCodeStorage",
     "bytecodePath": "artifacts-zk/contracts-preprocessed/AccountCodeStorage.sol/AccountCodeStorage.json",
     "sourceCodePath": "contracts-preprocessed/AccountCodeStorage.sol",
-    "bytecodeHash": "0x01000075d58c2cea1d80b434fb70e256b90ba0fbe7b0bd1f5dc70350f7bdfd34",
+    "bytecodeHash": "0x01000075f182aa28af1c665b6202f74046cfe8f123bc3a181e8b4153540a20f4",
     "sourceCodeHash": "0xfbf66e830201c4b7fda14f0ddf28a53beb7fbb48a8406392bcfd0ef7ea9265c8"
   },
   {
     "contractName": "BootloaderUtilities",
     "bytecodePath": "artifacts-zk/contracts-preprocessed/BootloaderUtilities.sol/BootloaderUtilities.json",
     "sourceCodePath": "contracts-preprocessed/BootloaderUtilities.sol",
-    "bytecodeHash": "0x010007d132c68997edf892423ae89079a3118e3506a6dad628b20a826c9ad0b7",
+    "bytecodeHash": "0x010007d14dc34bcd84457f09e4f87695cfbf89ac53a7f6760cd00d257fdd4edc",
     "sourceCodeHash": "0x9ff5a2da00acfa145ee4575381ad386587d96b6a0309d05015974f4726881132"
   },
   {
     "contractName": "ComplexUpgrader",
     "bytecodePath": "artifacts-zk/contracts-preprocessed/ComplexUpgrader.sol/ComplexUpgrader.json",
     "sourceCodePath": "contracts-preprocessed/ComplexUpgrader.sol",
-    "bytecodeHash": "0x010000556b7218497abf194231c563756850bcc745bb781069a5f06c07e55f34",
+    "bytecodeHash": "0x0100005555469224e2b2d2e3638dcbcf7ef152ca11aa3e1e8269f5cc6a87e6b3",
     "sourceCodeHash": "0x0aa5d7ed159e783acde47856b13801b7f2268ba39b2fa50807fe3d705c506e96"
   },
   {
     "contractName": "Compressor",
     "bytecodePath": "artifacts-zk/contracts-preprocessed/Compressor.sol/Compressor.json",
     "sourceCodePath": "contracts-preprocessed/Compressor.sol",
-    "bytecodeHash": "0x0100017918dd335119ac124f424fb25787682ece5c072cfbad6026e73fe3911f",
+    "bytecodeHash": "0x01000179c3ba9bfe693628d8abfeddccd7e397b21ca143f1fc6c51d6f72e5665",
     "sourceCodeHash": "0xd43ac120a50398e0d6bdcfcf807154bfeece0c231509a0eb2e00bcad744e60cd"
   },
   {
     "contractName": "ContractDeployer",
     "bytecodePath": "artifacts-zk/contracts-preprocessed/ContractDeployer.sol/ContractDeployer.json",
     "sourceCodePath": "contracts-preprocessed/ContractDeployer.sol",
-    "bytecodeHash": "0x010005210857411f7bd7433712d73ba533cb37ea58590f7479280ad2a02e3fd5",
+    "bytecodeHash": "0x010005217bdf9214ba5129189f00fad1829a9b86ca55d02d33c8a87b88c7c83e",
     "sourceCodeHash": "0x635301b824f927b4d17b3d9974cf6abbf979dda49e610805637db7c677d5f522"
   },
   {
     "contractName": "Create2Factory",
     "bytecodePath": "artifacts-zk/contracts-preprocessed/Create2Factory.sol/Create2Factory.json",
     "sourceCodePath": "contracts-preprocessed/Create2Factory.sol",
-    "bytecodeHash": "0x0100004b3423a2e2e5f444f29e44f904c7bf1cda21437d395fae1ce3dfb2cd81",
+    "bytecodeHash": "0x0100004b8abf7ae0c82a0fb866f957535ef3f4499126f48af46ed468df8ddfa1",
     "sourceCodeHash": "0x217e65f55c8add77982171da65e0db8cc10141ba75159af582973b332a4e098a"
   },
   {
     "contractName": "DefaultAccount",
     "bytecodePath": "artifacts-zk/contracts-preprocessed/DefaultAccount.sol/DefaultAccount.json",
     "sourceCodePath": "contracts-preprocessed/DefaultAccount.sol",
-    "bytecodeHash": "0x01000563426437b886b132bf5bcf9b0d98c3648f02a6e362893db4345078d09f",
+    "bytecodeHash": "0x010005632f2998000d55d4f2ffb1f8fd8ee25481dce6850af3e049cf2ce6d325",
     "sourceCodeHash": "0xa42423712ddaa8f357d26e46825fda80a9a870d0ac7ff52c98884355f1173ec7"
   },
   {
@@ -59,56 +59,56 @@
     "contractName": "ImmutableSimulator",
     "bytecodePath": "artifacts-zk/contracts-preprocessed/ImmutableSimulator.sol/ImmutableSimulator.json",
     "sourceCodePath": "contracts-preprocessed/ImmutableSimulator.sol",
-    "bytecodeHash": "0x0100003d4dd9f3871a68dc910240f389487d6e8d2d8b4ddc5e5aa8ed47cadd9f",
+    "bytecodeHash": "0x0100003db779b2096f17b31731f656528083a241fcb55a279474956a673c3454",
     "sourceCodeHash": "0x30df621c72cb35b8820b902b91057f72d0214a0e4a6b7ad4c0847e674e8b9df8"
   },
   {
     "contractName": "KnownCodesStorage",
     "bytecodePath": "artifacts-zk/contracts-preprocessed/KnownCodesStorage.sol/KnownCodesStorage.json",
     "sourceCodePath": "contracts-preprocessed/KnownCodesStorage.sol",
-    "bytecodeHash": "0x0100007d8ff9ee312f91dc4c507e3aaeb0a876d9a1937384645f2be8c3db21de",
+    "bytecodeHash": "0x0100007d47ed36a4af3118725468e9dd9e802d3fa1f6521b5d3a95d1f5fe7f01",
     "sourceCodeHash": "0x51d388adc58f67ef975a94a7978caa60ed8a0df9d3bd9ac723dfcfc540286c70"
   },
   {
     "contractName": "L1Messenger",
     "bytecodePath": "artifacts-zk/contracts-preprocessed/L1Messenger.sol/L1Messenger.json",
     "sourceCodePath": "contracts-preprocessed/L1Messenger.sol",
-    "bytecodeHash": "0x010002b92f1a7be267f5e192bd5fd24155250a47b8cf2f1300de89f691b60787",
+    "bytecodeHash": "0x010002b97f03e564ad1e89909955b98e81699f52fe394a9aea57e273dda36a7f",
     "sourceCodeHash": "0x35c189f3babf5c7a9ce2590bed9eb62b59766e358b7733fdb1bc33f4c232f765"
   },
   {
     "contractName": "L2BaseToken",
     "bytecodePath": "artifacts-zk/contracts-preprocessed/L2BaseToken.sol/L2BaseToken.json",
     "sourceCodePath": "contracts-preprocessed/L2BaseToken.sol",
-    "bytecodeHash": "0x0100011f147165d93b8ab21c15d6e123715da8ad8b8776c2da49bc890ffbe6e7",
-    "sourceCodeHash": "0x279f06761bb0704afee32747ecf22496588cc6dc6dddd4c9e928a2b7716ee930"
+    "bytecodeHash": "0x01000103cb97e28c9721e979f5bc38ecb6efa34992ac9d595ff0b0a591db9911",
+    "sourceCodeHash": "0x6a220ea431473bc8a1571b1a7c70b835dfe051e1cf38aac66302df33f9b11e9b"
   },
   {
     "contractName": "MsgValueSimulator",
     "bytecodePath": "artifacts-zk/contracts-preprocessed/MsgValueSimulator.sol/MsgValueSimulator.json",
     "sourceCodePath": "contracts-preprocessed/MsgValueSimulator.sol",
-    "bytecodeHash": "0x010000699913d2a25f0382355554ed72c258e58d90950ba2e3a83ab439318f73",
+    "bytecodeHash": "0x01000069fe7d04799e6ab0b9036a867f2eb00413bc58792f420081e12cc4ca34",
     "sourceCodeHash": "0x3f9e0af527875bebcdc20ca4ecb6822305877fd6038e4c4c58854d000b9ac115"
   },
   {
     "contractName": "NonceHolder",
     "bytecodePath": "artifacts-zk/contracts-preprocessed/NonceHolder.sol/NonceHolder.json",
     "sourceCodePath": "contracts-preprocessed/NonceHolder.sol",
-    "bytecodeHash": "0x010000e59b50f1c956a7427dfb7c1b33bcf9048ceeb4116eb26a6c5deef6184a",
+    "bytecodeHash": "0x010000e52b42aad6de5e55a6e737c1a508d52c96078c62052390c3544008813d",
     "sourceCodeHash": "0x91847512344ac5026e9fd396189c23ad9e253f22cb6e2fe65805c20c915797d4"
   },
   {
     "contractName": "PubdataChunkPublisher",
     "bytecodePath": "artifacts-zk/contracts-preprocessed/PubdataChunkPublisher.sol/PubdataChunkPublisher.json",
     "sourceCodePath": "contracts-preprocessed/PubdataChunkPublisher.sol",
-    "bytecodeHash": "0x0100004964f77bae7187bc6a9b0da9e9b22cbb34649f15fced75cbfebd812c63",
+    "bytecodeHash": "0x01000049fa09d33c1db6eb555d51fdd5861624a1cbe56b119ba0a947f664e4d2",
     "sourceCodeHash": "0xbc62d673c2cf9ba2d2148e5e2f99ea577cd357c6fd3ad7d248f670c750050faa"
   },
   {
     "contractName": "SystemContext",
     "bytecodePath": "artifacts-zk/contracts-preprocessed/SystemContext.sol/SystemContext.json",
     "sourceCodePath": "contracts-preprocessed/SystemContext.sol",
-    "bytecodeHash": "0x010001b3a795b0c8d25bcf0067b1537049c477b9bc578be425507d0194756e25",
+    "bytecodeHash": "0x010001b374483414b7d2ee052d665bb6836fc467909584b59ac6603f4b704cd9",
     "sourceCodeHash": "0xb90284d78f48a958d082c4c877fc91ec292d05f0e388c6c78e6cce6d3b069a63"
   },
   {
@@ -178,35 +178,35 @@
     "contractName": "bootloader_test",
     "bytecodePath": "bootloader/build/artifacts/bootloader_test.yul.zbin",
     "sourceCodePath": "bootloader/build/bootloader_test.yul",
-    "bytecodeHash": "0x010003cbee0cc4cd4d43faa6a6e8cd1750595aba444b37498bc61f9fe2cc3242",
-    "sourceCodeHash": "0xc9587a45167aafbfcec7fdafb3f6409f7341411eb9eba2231abdfa7de1f3d925"
+    "bytecodeHash": "0x010003cbad5678c968650a7bc2225d77667d2bc564c7c296cdabf8e303121356",
+    "sourceCodeHash": "0x69219bcc3c5edf0d7a18ff2870910f5f07861604b85c896a79dd3d0711517f4b"
   },
   {
     "contractName": "fee_estimate",
     "bytecodePath": "bootloader/build/artifacts/fee_estimate.yul.zbin",
     "sourceCodePath": "bootloader/build/fee_estimate.yul",
-    "bytecodeHash": "0x01000951296b20cb40d1473096cea5e1f07fbed1f5cce910ba8c98ee1eea6f47",
-    "sourceCodeHash": "0x232da808db40f37a78fe83b8faa73d4287da3a61a741e35259b9d3948991cfd7"
+    "bytecodeHash": "0x010009514c532c7747ad8eefc760d7609ece64181f616ff14db4e57db3bf9cf4",
+    "sourceCodeHash": "0xf4e3e69fdc19787b15fe54785bfc1364c0114bf1b39dfb45616cd909326fbe20"
   },
   {
     "contractName": "gas_test",
     "bytecodePath": "bootloader/build/artifacts/gas_test.yul.zbin",
     "sourceCodePath": "bootloader/build/gas_test.yul",
-    "bytecodeHash": "0x010008d71c14ef8264082251a434eaf7279aaec3c3d2b3132ebe4723b9d2ddbb",
-    "sourceCodeHash": "0x271c4762bd0ff170f127e45d4a526afc730d1820a59824dcce26b15d9e293c22"
+    "bytecodeHash": "0x010008d7e6a163173e78159e2f691632d37e85368eb5fefb6254f026303acae2",
+    "sourceCodeHash": "0x8f81075175a1d38941e81bac4988cad702ad99ec37abae17d200495036f447d0"
   },
   {
     "contractName": "playground_batch",
     "bytecodePath": "bootloader/build/artifacts/playground_batch.yul.zbin",
     "sourceCodePath": "bootloader/build/playground_batch.yul",
-    "bytecodeHash": "0x010009575d12cd2d588b852c43762aef66723ab2f2dddf9f526d7d90968e6654",
-    "sourceCodeHash": "0xe2597a2df37b33c2c0fe3d747327e2b60d3c5d2513aeddae65682fb3c6c33c9c"
+    "bytecodeHash": "0x01000957df369d8535215941b29e6b955d339b0d3351aa5e68ea04ecf73a99ce",
+    "sourceCodeHash": "0x0823ef2962a76e27d71cf08fed863c975ecb3a830bb065c944274b11aa1a2cde"
   },
   {
     "contractName": "proved_batch",
     "bytecodePath": "bootloader/build/artifacts/proved_batch.yul.zbin",
     "sourceCodePath": "bootloader/build/proved_batch.yul",
-    "bytecodeHash": "0x010008e74e40a94b1c6e6eb5a1dfbbdbd9eb9e0ec90fd358d29e8c07c30d8491",
-    "sourceCodeHash": "0xc6d5f3e95ac13ca3f6ddee215f2a868ac4e2cf2ecdbf89d65a2ccda86202814d"
+    "bytecodeHash": "0x010008e70db7e7f71ed38bcb9fa077806fb675f64d9df31eee6936d2246434e6",
+    "sourceCodeHash": "0x2cfca2c0c07758b2e01c15fa1880fec8d756a06cf0d9d04e9eafd67938bdc52b"
   }
 ]

--- a/system-contracts/contracts/L2BaseToken.sol
+++ b/system-contracts/contracts/L2BaseToken.sol
@@ -69,7 +69,7 @@ contract L2BaseToken is IBaseToken, ISystemContract {
 
     /// @notice Initiate the withdrawal of the base token, funds will be available to claim on L1 `finalizeEthWithdrawal` method.
     /// @param _l1Receiver The address on L1 to receive the funds.
-    function withdraw(bytes calldata _l1Receiver) external payable override {
+    function withdraw(bytes32 _l1Receiver) external payable override {
         uint256 amount = _burnMsgValue();
 
         // Send the L2 log, a user could use it as proof of the withdrawal
@@ -109,7 +109,7 @@ contract L2BaseToken is IBaseToken, ISystemContract {
     }
 
     /// @dev Get the message to be sent to L1 to initiate a withdrawal.
-    function _getL1WithdrawMessage(bytes calldata _to, uint256 _amount) internal pure returns (bytes memory) {
+    function _getL1WithdrawMessage(bytes32 _to, uint256 _amount) internal pure returns (bytes memory) {
         return abi.encodePacked(IMailbox.finalizeEthWithdrawal.selector, _to, _amount);
     }
 

--- a/system-contracts/contracts/interfaces/IBaseToken.sol
+++ b/system-contracts/contracts/interfaces/IBaseToken.sol
@@ -17,7 +17,7 @@ interface IBaseToken {
 
     function mint(address _account, uint256 _amount) external;
 
-    function withdraw(bytes calldata _l1Receiver) external payable;
+    function withdraw(bytes32 _l1Receiver) external payable;
 
     function withdrawWithMessage(address _l1Receiver, bytes calldata _additionalData) external payable;
 
@@ -25,7 +25,7 @@ interface IBaseToken {
 
     event Transfer(address indexed from, address indexed to, uint256 value);
 
-    event Withdrawal(address indexed _l2Sender, bytes indexed _l1Receiver, uint256 _amount);
+    event Withdrawal(address indexed _l2Sender, bytes32 indexed _l1Receiver, uint256 _amount);
 
     event WithdrawalWithMessage(
         address indexed _l2Sender,

--- a/system-contracts/package.json
+++ b/system-contracts/package.json
@@ -28,6 +28,8 @@
     "@types/lodash": "^4.14.199",
     "@types/mocha": "^8.2.3",
     "@types/node": "^17.0.34",
+    "bs58": "^6.0.0",
+    "bech32": "^2.0.0",
     "chai": "^4.3.10",
     "elliptic": "^6.5.4",
     "hardhat-typechain": "^0.3.3",

--- a/system-contracts/test/L2BaseToken.spec.ts
+++ b/system-contracts/test/L2BaseToken.spec.ts
@@ -8,6 +8,8 @@ import type { BigNumber } from "ethers";
 import { TEST_BOOTLOADER_FORMAL_ADDRESS, TEST_BASE_TOKEN_SYSTEM_CONTRACT_ADDRESS } from "./shared/constants";
 import { prepareEnvironment, setResult } from "./shared/mocks";
 import { randomBytes } from "crypto";
+import { bech32, bech32m } from "bech32";
+import bs58 from "bs58";
 
 describe("L2BaseToken tests", () => {
   const richWallet = getWallets()[0];
@@ -168,14 +170,19 @@ describe("L2BaseToken tests", () => {
   });
 
   describe("withdraw", () => {
-    it("event, balance, totalsupply", async () => {
+    it("event, balance, totalsupply with P2PKH address", async () => {
       const amountToWithdraw: BigNumber = ethers.utils.parseEther("1.0");
-      const btcAddress = ethers.utils.hexlify(
-        ethers.utils.toUtf8Bytes("bc1qy82gaw2htfd5sslplpgmz4ktf9y3k7pac2226k0wljlmw3atfw5qwm4av4")
-      );
+      // Example Base58 address (P2PKH address)
+      const base58Address = "1A1zP1eP5QGefi2DMPTfTL5SLmv7DivfNa";
+
+      // Decode Base58 address to bytes
+      const base85BtcAddressBytes = bs58.decode(base58Address);
+      const hexString = ethers.utils.hexlify(base85BtcAddressBytes);
+      const btcAddressBytes32 = ethers.utils.hexZeroPad(hexString, 32);
+
       const message: string = ethers.utils.solidityPack(
         ["bytes4", "bytes", "uint256"],
-        [mailboxIface.getSighash("finalizeEthWithdrawal"), btcAddress, amountToWithdraw]
+        [mailboxIface.getSighash("finalizeEthWithdrawal"), btcAddressBytes32, amountToWithdraw]
       );
 
       await setResult("L1Messenger", "sendToL1", [message], {
@@ -190,9 +197,87 @@ describe("L2BaseToken tests", () => {
       const balanceBeforeWithdrawal: BigNumber = await L2BaseToken.balanceOf(L2BaseToken.address);
       const totalSupplyBefore = await L2BaseToken.totalSupply();
 
-      await expect(L2BaseToken.connect(richWallet).withdraw(btcAddress, { value: amountToWithdraw }))
+      await expect(L2BaseToken.connect(richWallet).withdraw(btcAddressBytes32, { value: amountToWithdraw }))
         .to.emit(L2BaseToken, "Withdrawal")
-        .withArgs(richWallet.address, btcAddress, amountToWithdraw);
+        .withArgs(richWallet.address, btcAddressBytes32, amountToWithdraw);
+
+      const balanceAfterWithdrawal: BigNumber = await L2BaseToken.balanceOf(L2BaseToken.address);
+      const totalSupplyAfter = await L2BaseToken.totalSupply();
+
+      expect(balanceAfterWithdrawal).to.equal(balanceBeforeWithdrawal.sub(amountToWithdraw));
+      expect(totalSupplyAfter).to.equal(totalSupplyBefore.sub(amountToWithdraw));
+    });
+
+    it("event, balance, totalsupply with Bech32 address", async () => {
+      const amountToWithdraw: BigNumber = ethers.utils.parseEther("1.0");
+      const bech32Address = "bc1qy82gaw2htfd5sslplpgmz4ktf9y3k7pac2226k0wljlmw3atfw5qwm4av4";
+      const bech32DecodedAddress = bech32.decode(bech32Address, 90);
+      // Extract the payload (excluding the witness first byte)
+      const payload = bech32DecodedAddress.words.slice(1);
+      // Convert the payload from words to bytes
+      const payloadBytes = bech32.fromWords(payload);
+      const hexString = ethers.utils.hexlify(payloadBytes);
+      const btcAddressBytes32 = ethers.utils.hexZeroPad(hexString, 32);
+
+      const message: string = ethers.utils.solidityPack(
+        ["bytes4", "bytes", "uint256"],
+        [mailboxIface.getSighash("finalizeEthWithdrawal"), btcAddressBytes32, amountToWithdraw]
+      );
+
+      await setResult("L1Messenger", "sendToL1", [message], {
+        failure: false,
+        returnData: ethers.utils.defaultAbiCoder.encode(["bytes32"], [ethers.utils.keccak256(message)]),
+      });
+
+      // To prevent underflow since initial values are 0's and we are subtracting from them
+      const amountToMint: BigNumber = ethers.utils.parseEther("100.0");
+      await (await L2BaseToken.connect(bootloaderAccount).mint(L2BaseToken.address, amountToMint)).wait();
+
+      const balanceBeforeWithdrawal: BigNumber = await L2BaseToken.balanceOf(L2BaseToken.address);
+      const totalSupplyBefore = await L2BaseToken.totalSupply();
+
+      await expect(L2BaseToken.connect(richWallet).withdraw(btcAddressBytes32, { value: amountToWithdraw }))
+        .to.emit(L2BaseToken, "Withdrawal")
+        .withArgs(richWallet.address, btcAddressBytes32, amountToWithdraw);
+
+      const balanceAfterWithdrawal: BigNumber = await L2BaseToken.balanceOf(L2BaseToken.address);
+      const totalSupplyAfter = await L2BaseToken.totalSupply();
+
+      expect(balanceAfterWithdrawal).to.equal(balanceBeforeWithdrawal.sub(amountToWithdraw));
+      expect(totalSupplyAfter).to.equal(totalSupplyBefore.sub(amountToWithdraw));
+    });
+
+    it("event, balance, totalsupply with Bech32m address", async () => {
+      const amountToWithdraw: BigNumber = ethers.utils.parseEther("1.0");
+      const bech32mAddress = "bc1p5d7rjq7g6rdk2yhzks9smlaqtedr4dekq08ge8ztwac72sfr9rusxg3297";
+      const bech32mDecodedAddress = bech32m.decode(bech32mAddress, 90);
+      // Extract the payload (excluding the witness first byte)
+      const payload = bech32mDecodedAddress.words.slice(1);
+      // Convert the payload from words to bytes
+      const payloadBytes = bech32.fromWords(payload);
+      const hexString = ethers.utils.hexlify(payloadBytes);
+      const btcAddressBytes32 = ethers.utils.hexZeroPad(hexString, 32);
+
+      const message: string = ethers.utils.solidityPack(
+        ["bytes4", "bytes", "uint256"],
+        [mailboxIface.getSighash("finalizeEthWithdrawal"), btcAddressBytes32, amountToWithdraw]
+      );
+
+      await setResult("L1Messenger", "sendToL1", [message], {
+        failure: false,
+        returnData: ethers.utils.defaultAbiCoder.encode(["bytes32"], [ethers.utils.keccak256(message)]),
+      });
+
+      // To prevent underflow since initial values are 0's and we are subtracting from them
+      const amountToMint: BigNumber = ethers.utils.parseEther("100.0");
+      await (await L2BaseToken.connect(bootloaderAccount).mint(L2BaseToken.address, amountToMint)).wait();
+
+      const balanceBeforeWithdrawal: BigNumber = await L2BaseToken.balanceOf(L2BaseToken.address);
+      const totalSupplyBefore = await L2BaseToken.totalSupply();
+
+      await expect(L2BaseToken.connect(richWallet).withdraw(btcAddressBytes32, { value: amountToWithdraw }))
+        .to.emit(L2BaseToken, "Withdrawal")
+        .withArgs(richWallet.address, btcAddressBytes32, amountToWithdraw);
 
       const balanceAfterWithdrawal: BigNumber = await L2BaseToken.balanceOf(L2BaseToken.address);
       const totalSupplyAfter = await L2BaseToken.totalSupply();

--- a/yarn.lock
+++ b/yarn.lock
@@ -2183,6 +2183,11 @@ base-x@^3.0.2:
   dependencies:
     safe-buffer "^5.0.1"
 
+base-x@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/base-x/-/base-x-5.0.0.tgz#6d835ceae379130e1a4cb846a70ac4746f28ea9b"
+  integrity sha512-sMW3VGSX1QWVFA6l8U62MLKz29rRfpTlYdCqLdpLo1/Yd4zZwSbnUaDfciIAowAqvq7YFnWq9hrhdg1KYgc1lQ==
+
 base64-js@^1.3.1:
   version "1.5.1"
   resolved "https://registry.yarnpkg.com/base64-js/-/base64-js-1.5.1.tgz#1b1b440160a5bf7ad40b650f095963481903930a"
@@ -2199,6 +2204,11 @@ bech32@1.1.4:
   version "1.1.4"
   resolved "https://registry.yarnpkg.com/bech32/-/bech32-1.1.4.tgz#e38c9f37bf179b8eb16ae3a772b40c356d4832e9"
   integrity sha512-s0IrSOzLlbvX7yp4WBfPITzpAU8sqQcpsmwXDiKwrG4r491vwCO/XpejasRNl0piBMe/DvP4Tz0mIS/X1DPJBQ==
+
+bech32@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/bech32/-/bech32-2.0.0.tgz#078d3686535075c8c79709f054b1b226a133b355"
+  integrity sha512-LcknSilhIGatDAsY1ak2I8VtGaHNhgMSYVxFrGLXv+xLHytaKZKcaUJJUE7qmBr7h33o5YQwP55pMI0xmkpJwg==
 
 bignumber.js@^9.0.0, bignumber.js@^9.0.1:
   version "9.1.2"
@@ -2321,6 +2331,13 @@ bs58@^4.0.0:
   integrity sha512-Ok3Wdf5vOIlBrgCvTq96gBkJw+JUEzdBgyaza5HLtPm7yTHkjRy8+JzNyHF7BHa0bNWOQIp3m5YF0nnFcOIKLw==
   dependencies:
     base-x "^3.0.2"
+
+bs58@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/bs58/-/bs58-6.0.0.tgz#a2cda0130558535dd281a2f8697df79caaf425d8"
+  integrity sha512-PD0wEnEYg6ijszw/u8s+iI3H17cTymlrwkKhDhPZq+Sokl3AU4htyBFTjAeNAlCCmg0f53g6ih3jATyCKftTfw==
+  dependencies:
+    base-x "^5.0.0"
 
 bs58check@^2.1.2:
   version "2.1.2"


### PR DESCRIPTION
# What ❔

- Change the receiver l1 address datatype to bytes32.
- Add tests for bech32, bech32m and P2PKH.

## Checklist

- [X] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [X] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
