### PR TITLE
fix: set the base token decimals to 18

### DIFF
--- a/system-contracts/SystemContractsHashes.json
+++ b/system-contracts/SystemContractsHashes.json
@@ -80,8 +80,8 @@
     "contractName": "L2BaseToken",
     "bytecodePath": "artifacts-zk/contracts-preprocessed/L2BaseToken.sol/L2BaseToken.json",
     "sourceCodePath": "contracts-preprocessed/L2BaseToken.sol",
-    "bytecodeHash": "0x0100011f147165d93b8ab21c15d6e123715da8ad8b8776c2da49bc890ffbe6e7",
-    "sourceCodeHash": "0x279f06761bb0704afee32747ecf22496588cc6dc6dddd4c9e928a2b7716ee930"
+    "bytecodeHash": "0x0100011f5e239fda40b5e5decb9fbc529f5b4670ed85f9a75a9d7557cbea4362",
+    "sourceCodeHash": "0xf0e9f7301a8ec27ca8ed4a9d7e7f316aa6a9c9301ce67b972f5e0fb77ff3c77a"
   },
   {
     "contractName": "MsgValueSimulator",

--- a/system-contracts/contracts/L2BaseToken.sol
+++ b/system-contracts/contracts/L2BaseToken.sol
@@ -139,6 +139,6 @@ contract L2BaseToken is IBaseToken, ISystemContract {
     /// @dev This method has not been stabilized and might be
     /// removed later on.
     function decimals() external pure override returns (uint8) {
-        return 8;
+        return 18;
     }
 }

--- a/system-contracts/test/L2BaseToken.spec.ts
+++ b/system-contracts/test/L2BaseToken.spec.ts
@@ -163,7 +163,7 @@ describe("L2BaseToken tests", () => {
   describe("decimals", () => {
     it("correct decimals", async () => {
       const decimals = await L2BaseToken.decimals();
-      expect(decimals).to.equal(8);
+      expect(decimals).to.equal(18);
     });
   });
 


### PR DESCRIPTION
# What ❔

- Update the base token decimal to 18

## Checklist

- [X] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [X] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
